### PR TITLE
bindings: refactor sign/sign_indexed_raw_transaction

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,8 @@
 name: CI
 
 on:
-  push:
-    branches: [ main, "*-dev*" ]
   pull_request:
-    branches: [ main, "*-dev*" ]
+    branches: [ "*" ]
 
 jobs:
   build:
@@ -181,6 +179,7 @@ jobs:
             python3 tooltests.py
             if ([ "${{ matrix.name }}" == "" ]); then
                 python3 -m unittest bindings/py_wrappers/pytest/address_test.py
+                python3 -m unittest bindings/py_wrappers/pytest/transaction_test.py
             fi
 
       - name: Upload artifacts

--- a/bindings/py_wrappers/libdogecoin/wrappers.py
+++ b/bindings/py_wrappers/libdogecoin/wrappers.py
@@ -408,19 +408,14 @@ def sign_raw_transaction(input_index, incoming_raw_tx, script_hex, sig_hash_type
 
     # set types for parameters and return
     lib.sign_raw_transaction.argtypes = [ct.c_int, ct.c_char_p, ct.c_char_p, ct.c_int, ct.c_int, ct.c_char_p]
-    lib.sign_raw_transaction.restype = ct.c_int
+    lib.sign_raw_transaction.restype = ct.c_char_p
 
     # call c function
-    lib.dogecoin_ecc_start()
-    res = ct.c_int()
-    res = lib.sign_raw_transaction(input_index, incoming_raw_tx_ptr, script_hex_ptr, sig_hash_type, amount, privkey_ptr)
-    lib.dogecoin_ecc_stop()
-
-    # return signed transaction hex if successful, 0 otherwise
-    if res==1:
-        return incoming_raw_tx_ptr.value.decode("utf-8")
-    else:
-        return int(res)
+    try:
+        incoming_raw_tx_ptr = lib.sign_raw_transaction(input_index, incoming_raw_tx_ptr, script_hex_ptr, sig_hash_type, amount, privkey_ptr).decode("utf-8")
+        return incoming_raw_tx_ptr
+    except:
+        return 0
 
 def sign_indexed_raw_transaction(tx_index, input_index, incoming_raw_tx, script_hex, sig_hash_type, amount, privkey):
     """Sign a finalized raw transaction using the specified
@@ -450,15 +445,10 @@ def sign_indexed_raw_transaction(tx_index, input_index, incoming_raw_tx, script_
 
     # set types for parameters and return
     lib.sign_indexed_raw_transaction.argtypes = [ct.c_int, ct.c_int, ct.c_char_p, ct.c_char_p, ct.c_int, ct.c_int, ct.c_char_p]
-    lib.sign_indexed_raw_transaction.restype = ct.c_int
+    lib.sign_indexed_raw_transaction.restype = ct.c_char_p
 
     # call c function
-    lib.dogecoin_ecc_start()
-    res = lib.sign_indexed_raw_transaction(tx_index, input_index, incoming_raw_tx_ptr, script_hex_ptr, sig_hash_type, amount, privkey_ptr)
-    lib.dogecoin_ecc_stop()
+    incoming_raw_tx_ptr = lib.sign_indexed_raw_transaction(tx_index, input_index, incoming_raw_tx_ptr, script_hex_ptr, sig_hash_type, amount, privkey_ptr).decode("utf-8")
 
     # return result
-    try:
-        return incoming_raw_tx_ptr.value.decode("utf-8")
-    except:
-        return 0
+    return incoming_raw_tx_ptr

--- a/bindings/py_wrappers/pytest/transaction_test.py
+++ b/bindings/py_wrappers/pytest/transaction_test.py
@@ -105,28 +105,34 @@ class TestTransactionFunctions(unittest.TestCase):
         self.assertFalse(rawhex)
 
     def test_sign_raw_transaction(self):
+        w.dogecoin_ecc_start()
         idx = w.start_transaction()
         w.add_utxo(idx, hash2doge, vout2doge)
         w.add_utxo(idx, hash10doge, vout10doge)
         w.add_output(idx, external_p2pkh_addr, send_amt)
         rawhex = w.finalize_transaction(idx, external_p2pkh_addr, fee, total_utxo_input, p2pkh_addr)
         self.assertTrue(rawhex==expected_unsigned_tx_hex)
-        rawhex = w.sign_raw_transaction(0, rawhex, utxo_scriptpubkey, 1, 2, privkey_wif)
+        rawhex = w.sign_raw_transaction(0, w.get_raw_transaction(idx), utxo_scriptpubkey, 1, 2, privkey_wif)
         self.assertTrue(rawhex==expected_signed_single_input_tx_hex)
-        rawhex = w.sign_raw_transaction(1, rawhex, utxo_scriptpubkey, 1, 10, privkey_wif)
+        w.save_raw_transaction(idx, rawhex)
+        rawhex = w.sign_raw_transaction(1, w.get_raw_transaction(idx), utxo_scriptpubkey, 1, 10, privkey_wif)
         self.assertTrue(rawhex==expected_signed_raw_tx_hex)
+        w.dogecoin_ecc_stop()
 
     def test_sign_indexed_raw_transaction(self):
+        w.dogecoin_ecc_start()
         idx = w.start_transaction()
         w.add_utxo(idx, hash2doge, vout2doge)
         w.add_utxo(idx, hash10doge, vout10doge)
         w.add_output(idx, external_p2pkh_addr, send_amt)
         rawhex = w.finalize_transaction(idx, external_p2pkh_addr, fee, total_utxo_input, p2pkh_addr)
         self.assertTrue(rawhex==expected_unsigned_tx_hex)
-        rawhex = w.sign_indexed_raw_transaction(idx, 0, rawhex, utxo_scriptpubkey, 1, 2, privkey_wif)
-        self.assertTrue(rawhex==expected_signed_single_input_tx_hex)
+        w.save_raw_transaction(idx, rawhex)
+        rawhex = w.sign_indexed_raw_transaction(idx, 0, w.get_raw_transaction(idx), utxo_scriptpubkey, 1, 2, privkey_wif)
+        self.assertTrue(w.get_raw_transaction(idx)==expected_signed_single_input_tx_hex)
         rawhex = w.sign_indexed_raw_transaction(idx, 1, rawhex, utxo_scriptpubkey, 1, 10, privkey_wif)
         self.assertTrue(rawhex==expected_signed_raw_tx_hex)
+        w.dogecoin_ecc_stop()
         
 if __name__ == "__main__":
     test_src = inspect.getsource(TestTransactionFunctions)

--- a/include/dogecoin/dogecoin.h
+++ b/include/dogecoin/dogecoin.h
@@ -97,7 +97,7 @@ typedef SSIZE_T ssize_t;
 
 #endif
 
-#define DEBUG 0
+#define DEBUG 1
 #ifdef DEBUG
 #define debug_print(fmt, ...) \
         do { if (DEBUG) fprintf(stderr, "%s:%d:%s(): " fmt, __FILE__, \

--- a/include/dogecoin/transaction.h
+++ b/include/dogecoin/transaction.h
@@ -86,8 +86,8 @@ LIBDOGECOIN_API void clear_transaction(int txindex); // #clears a tx in memory. 
 // sign a given inputted transaction with a given private key, and return a hex signed transaction.
 // we may want to add such things to 'advanced' section:
 // locktime, possibilities for multiple outputs, data, sequence.
-LIBDOGECOIN_API int sign_raw_transaction(int inputindex, char* incomingrawtx, char* scripthex, int sighashtype, int amount, char* privkey);
-LIBDOGECOIN_API int sign_indexed_raw_transaction(int txindex, int inputindex, char* incomingrawtx, char* scripthex, int sighashtype, int amount, char* privkey);
+LIBDOGECOIN_API char* sign_raw_transaction(int inputindex, char* incomingrawtx, char* scripthex, int sighashtype, int amount, char* privkey);
+LIBDOGECOIN_API char* sign_indexed_raw_transaction(int txindex, int inputindex, char* incomingrawtx, char* scripthex, int sighashtype, int amount, char* privkey);
 
 LIBDOGECOIN_END_DECL
 

--- a/src/cli/such.c
+++ b/src/cli/such.c
@@ -147,14 +147,8 @@ void signing_menu(int txindex, int is_testnet) {
                     // 76a914d8c43e6f68ca4ea1e9b93da2d1e3a95118fa4a7c88ac
                     raw_hexadecimal_tx = get_raw_transaction(txindex);
                     // 76a914d8c43e6f68ca4ea1e9b93da2d1e3a95118fa4a7c88ac
-                    if (!sign_indexed_raw_transaction(txindex, input_to_sign, raw_hexadecimal_tx, script_pubkey, 1, input_amount, private_key_wif)) {
-                        printf("1) sign_indexed_raw_transaction failed! please try again!\n");
-                        printf("input_amount: %Lf\n", input_amount);
-                        printf("input_to_sign: %d\n", input_to_sign);
-                        printf("raw_hexadecimal_transaction: %s\n", raw_hexadecimal_tx);
-                        printf("script_pubkey: %s\n", script_pubkey);
-                        printf("private_key: %s\n", private_key_wif);
-                    }
+                    sign_indexed_raw_transaction(txindex, input_to_sign, raw_hexadecimal_tx, script_pubkey, 1, input_amount, private_key_wif);
+                    printf("transaction input successfully signed!\n");
                     break;
                 case 2:
                     input_amount = atol(getl("input amount")); // 2 & 10
@@ -168,14 +162,8 @@ void signing_menu(int txindex, int is_testnet) {
                     debug_print("script_pubkey: %s\n", script_pubkey);
                     debug_print("input_to_sign: %d\n", input_to_sign);
                     debug_print("private_key: %s\n", private_key_wif);
-                    if (!sign_indexed_raw_transaction(txindex, input_to_sign, raw_hexadecimal_tx, script_pubkey, 1, input_amount, private_key_wif)) {
-                        printf("2) sign_indexed_raw_transaction failed! please try again!\n");
-                        printf("input_amount: %Lf\n", input_amount);
-                        printf("input_to_sign: %d\n", input_to_sign);
-                        printf("raw_hexadecimal_transaction: %s\n", raw_hexadecimal_tx);
-                        printf("script_pubkey: %s\n", script_pubkey);
-                        printf("private_key: %s\n", private_key_wif);
-                    }
+                    sign_indexed_raw_transaction(txindex, input_to_sign, raw_hexadecimal_tx, script_pubkey, 1, input_amount, private_key_wif);
+                    printf("transaction input successfully signed!\n");
                     break;
                 case 3:
                     printf("raw_tx: %s\n", get_raw_transaction(txindex));

--- a/src/cstr.c
+++ b/src/cstr.c
@@ -35,11 +35,8 @@ static int cstr_alloc_min_sz(cstring* s, size_t sz)
     while ((al_sz = (1 << shift)) < sz) {
         shift++;
     }
-    if (s->str) {
-        new_s = dogecoin_realloc(s->str, al_sz);
-    }
-    else new_s = dogecoin_malloc(al_sz);
-    
+
+    new_s = dogecoin_realloc(s->str, al_sz);
     if (!new_s) {
         return 0;
     }
@@ -82,7 +79,7 @@ int cstr_alloc_minsize(cstring* s, size_t new_sz)
     }
 
     /* contents of string tail undefined */
-    s->len = new_sz;
+    // s->len = new_sz;
     s->str[s->len] = 0;
 
     return 1;

--- a/src/tx.c
+++ b/src/tx.c
@@ -598,7 +598,7 @@ char* dogecoin_private_key_wif_to_script_hash(char* private_key_wif) {
     dogecoin_pubkey_getaddr_p2pkh(&pubkey, chain, new_p2pkh_pubkey);
     dogecoin_privkey_cleanse(&key);
     dogecoin_pubkey_cleanse(&pubkey);
-    return dogecoin_p2pkh_to_script_hash(new_p2pkh_pubkey);;
+    return dogecoin_p2pkh_to_script_hash(new_p2pkh_pubkey);
 }
 
 /**

--- a/test/transaction_tests.c
+++ b/test/transaction_tests.c
@@ -293,7 +293,7 @@ void test_transaction()
 
     // sign current working transaction input index 0 of raw tx hex with script pubkey from utxo with sighash type of 1 (SIGHASH_ALL),
     // amount of 2 dogecoin represented as koinu (multiplied by 100 million) and with private key in wif format
-    u_assert_int_eq(sign_raw_transaction(0, raw_hexadecimal_transaction, utxo_scriptpubkey, 1, 2.0, private_key_wif), 1);
+    raw_hexadecimal_transaction = sign_raw_transaction(0, raw_hexadecimal_transaction, utxo_scriptpubkey, 1, 2.0, private_key_wif);
 
     // assert that our hexadecimal buffer (raw_hexadecimal_transaction) is equal to the expected transaction
     // with the first input signed:
@@ -303,8 +303,8 @@ void test_transaction()
 
     // sign current working transaction input index 1 of raw tx hex with script pubkey from utxo with sighash type of 1 (SIGHASH_ALL),
     // amount of 10 dogecoin represented as koinu (multiplied by 100 million) and with private key in wif format
-    u_assert_int_eq(sign_raw_transaction(1, raw_hexadecimal_transaction, utxo_scriptpubkey, 1, 10, private_key_wif), 1);
-
+    raw_hexadecimal_transaction = sign_raw_transaction(1, raw_hexadecimal_transaction, utxo_scriptpubkey, 1, 10, private_key_wif);
+    
     // assert that our hexadecimal bufer (raw_hexadecimal_transaction) is equal to the expected finalized
     // transaction with both inputs signed:
     u_assert_str_eq(raw_hexadecimal_transaction, our_expected_signed_raw_hexadecimal_transaction);

--- a/test/utils_tests.c
+++ b/test/utils_tests.c
@@ -40,12 +40,12 @@ void test_utils()
     utils_hex_to_bin(hex, data2, strlen(hex), &outlen);
     assert(outlen == 8);
     assert(memcmp(data, data2, outlen) == 0);
-    hash_bin = utils_hex_to_uint8(hash_buffer_exc);
+    utils_hex_to_uint8(hash_buffer_exc);
 
     /* test upper and lowercase A / F */
     utils_hex_to_bin(hex2, data3, strlen(hex2), &outlen);
-    hash_bin = utils_hex_to_uint8(hex2);
-    utils_clear_buffers();
+    utils_hex_to_uint8(hex2);
+    // utils_clear_buffers();
 
     /* stress test conversion between coins and koinu, round values */
     long double coin_amounts[] =   {1.0e-9, 1.0e-8, 
@@ -74,7 +74,7 @@ void test_utils()
     uint64_t diff;
     for (int i=0; i<20; i++) {
         actual_answer = coins_to_koinu(coin_amounts[i]);
-        debug_print("T%d\n\tcoin_amt: %f\n\texpected: %lu\n\tactual: %lu\n\n", i, coin_amounts[i], exp_answers[i], actual_answer);
+        debug_print("T%d\n\tcoin_amt: %.8Lf\n\texpected: %lu\n\tactual: %lu\n\n", i, coin_amounts[i], exp_answers[i], actual_answer);
         diff = exp_answers[i] - actual_answer;
         u_assert_int_eq((int)diff, 0);
     }


### PR DESCRIPTION
changed sign_raw_transaction and sign_indexed_raw_transaction so they return the raw_signed_tx as char* instead of an int to indicate success. this along with a few tweaks to wrappers.py ended up fixing the memory errors that were happening in the last 2 python transaction unit tests but it should be noted we should investigate futher into why ctypes was breaking.
updated signing menu segfault in such -c transaction.
reverted cstr_alloc_min_sz.
add python wrapper unit tests for x86_64-linux-dbg only.
removed ci run on push (will only trigger on pull request).